### PR TITLE
Enable LSP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,22 @@ Macaulay2. To enable it:
 pip install jupyterlab-lsp
 ```
 
-The kernel package already includes the spec that registers `M2-language-server` with
-`jupyter-lsp` automatically.  No additional configuration is required.
+The kernel package includes the spec that registers `M2-language-server` with
+`jupyter-lsp` automatically.  It will also symlink the Macaulay2 source directory
+so that the "Jump to definition" feature will work, provided that you start
+JupyterLab with the following option:
+
+```bash
+jupyter lab --ContentsManager.allow_hidden=True
+```
+
+Or, to save this setting for future sessions, add the following to
+`~/.jupyter/jupyter_server_config` (after running
+`jupyter server --generate-config` if it doesn't exist):
+
+```python
+c.ContentsManager.allow_hidden=True
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ This isn't a problem when using the default display mode.
 On the other hand, client-side syntax highlighting, such as in the screenshots,
 is missing entirely. -->
 
+## LSP Support
+
+[JupyterLab LSP](https://github.com/jupyter-lsp/jupyterlab-lsp) support is
+available for Macaulay2 via the `M2-language-server` binary bundled with
+Macaulay2. To enable it:
+
+```bash
+pip install jupyterlab-lsp
+```
+
+The kernel package already includes the spec that registers `M2-language-server` with
+`jupyter-lsp` automatically.  No additional configuration is required.
+
 ## License
 
 This software is not part of Macaulay2 and is released under the MIT License.

--- a/m2_kernel/assets/m2-code/JupyterKernel.m2
+++ b/m2_kernel/assets/m2-code/JupyterKernel.m2
@@ -103,3 +103,15 @@ show URL := url -> (
 	mimetype := first lines get(mimetypecmd | file);
 	if match("^image", mimetype) then print IMG("src" => file)
 	else windowOpen("/files/" | file)))
+
+-- create symlinks for LSP
+lspSymlink = ".lsp_symlink"
+createSymlink = dir -> (
+    dir = replace("/*$", "", dir); -- remove trailing slashes
+    if not fileExists(lspSymlink | dir)
+    then (
+	m := regex("^(.*)/[^/]+$", dir); -- parent directory
+	makeDirectory(lspSymlink | substring(m#1, dir));
+	symlinkFile(dir, lspSymlink | dir)))
+
+createSymlink(prefixDirectory | currentLayout#"packages")

--- a/m2_kernel/lsp_spec.py
+++ b/m2_kernel/lsp_spec.py
@@ -1,0 +1,13 @@
+import shutil
+
+def load(mgr):
+    cmd = shutil.which("M2-language-server")
+    return {
+        "macaulay2": {
+            "version": 2,
+            "argv": [cmd] if cmd else [],
+            "languages": ["macaulay2"],
+            "mime_types": ["text/x-macaulay2"],
+            "display_name": "Macaulay2",
+        }
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,5 +30,8 @@ Homepage = "https://github.com/Macaulay2/Macaulay2-Jupyter-Kernel"
 [project.optional-dependencies]
 test = ["jupyter-kernel-test"]
 
+[project.entry-points."jupyter_lsp_spec_v1"]
+macaulay2 = "m2_kernel.lsp_spec:load"
+
 [tool.setuptools]
 packages = ["m2_kernel"]


### PR DESCRIPTION
Draft for now until https://github.com/Macaulay2/M2/pull/3655 is merged.

This is a little gimpy compared to the Emacs, VS Code, and Neovim server interfaces.  The documentation and definition links are all locations that the Jupyter server can't access.  I think I'll likely add a command line option to `M2-language-server` to transform these links to something available on the web (similar to what we do in the kernel).

*Edit:* Jumping to definition works now (kind of -- it requires fiddling with JupyterLab's settings, but this is documented in `jupyterlab-lsp`'s README.)  I think getting links to work in hover documentation is going to require some changes to the server.

## AI Disclosure

Significant assistance from Claude Code