### PR TITLE
Use native M2 text output for text/plain

### DIFF
--- a/m2_kernel/assets/m2-code/JupyterKernel.m2
+++ b/m2_kernel/assets/m2-code/JupyterKernel.m2
@@ -25,10 +25,58 @@ ZZ#{Jupyter, InputContinuationPrompt} = x -> "... : "
 getMethod = symb -> x -> (lookup({jupyterMode, symb}, class x) ?? identity) x
 Thing#{Jupyter, BeforePrint}  = getMethod BeforePrint
 Thing#{Jupyter, NoPrint}      = getMethod NoPrint
-Thing#{Jupyter, Print}        = getMethod Print
-Thing#{Jupyter, AfterPrint}   = getMethod AfterPrint
-Thing#{Jupyter, AfterNoPrint} = getMethod AfterNoPrint
-Thing#{Jupyter, print}        = getMethod print
+
+-- Control characters for native text output (sent alongside HTML for text/plain MIME)
+jupyterTextTag    = "\x1f" -- opens native text region
+jupyterTextEndTag = "\x16" -- closes native text region
+
+emitText = n -> << jupyterTextTag << concatenate between(newline, unstack n) << jupyterTextEndTag;
+
+emitTextValue = x -> (
+    if jupyterMode === Standard then return;
+    oprompt := concatenate(interpreterDepth:"o", toString lineNumber, " = ");
+    save := printWidth;
+    if printWidth != 0 then printWidth = printWidth - #oprompt;
+    n := net x;
+    printWidth = save;
+    -- Net | Net horizontally joins with proper row alignment, then flatten to string
+    emitText((net oprompt) | n);
+    )
+
+emitTextAfter = (sym, x) -> (
+    if jupyterMode === Standard then return;
+    l := lookup(sym, class x);
+    if l === null then return;
+    s := l x;
+    if s === null then return;
+    oprompt := concatenate(interpreterDepth:"o", toString lineNumber, " : ");
+    parts := select(toList deepSplice sequence s, p -> p =!= null);
+    if #parts === 0 then return;
+    n := horizontalJoin apply(parts, net);
+    emitText((net oprompt) | n);
+    )
+
+Thing#{Jupyter, Print} = x -> (
+    (getMethod Print) x;
+    emitTextValue x;
+    )
+Nothing#{Jupyter, Print} = identity
+
+Thing#{Jupyter, AfterPrint} = x -> (
+    (getMethod AfterPrint) x;
+    emitTextAfter(AfterPrint, x);
+    )
+Thing#{Jupyter, AfterNoPrint} = x -> (
+    (getMethod AfterNoPrint) x;
+    emitTextAfter(AfterNoPrint, x);
+    )
+Thing#{Jupyter, print} = x -> (
+    if (f := lookup({jupyterMode, print}, class x)) =!= null
+    then (
+        f x;
+        emitText net x)
+    else << net x << endl;
+    )
 
 changeJupyterMode = mode -> (
     jupyterMode = mode;

--- a/m2_kernel/kernel.py
+++ b/m2_kernel/kernel.py
@@ -19,6 +19,13 @@ class M2Display:
     def __repr__(self):
         return self._text
 
+class M2Text:
+    "Plain text display for standard mode output."
+    def __init__(self, text):
+        self._text = text
+    def __repr__(self):
+        return self._text
+
 class M2Kernel(ProcessMetaKernel):
     implementation = "macaulay2_jupyter_kernel"
     implementation_version = __version__
@@ -151,8 +158,47 @@ class M2Kernel(ProcessMetaKernel):
 
             return M2Display("".join(html), "\n\n".join(text))
 
-        else:
-            self.Write(repr(output))
+        else:  # standard mode
+            output = repr(output).strip()
+            if not output:
+                return None
+            items = []
+            for block in re.split(r'(?=^o\d+\s+[=:])', output, flags=re.MULTILINE):
+                block = block.strip()
+                if not block:
+                    continue
+                m = re.search(r'^(o\d+)\s+[=:]', block, re.MULTILINE)
+                if m:
+                    items.append(('prompted', block, m.group(1)))
+                else:
+                    items.append(('gap', block, None))
+            # Merge consecutive prompted items with the same prompt number
+            merged = []
+            for kind, content, prompt in items:
+                if (kind == 'prompted' and merged
+                        and merged[-1][0] == 'prompted'
+                        and merged[-1][2] == prompt):
+                    merged[-1][1] += '\n\n' + content
+                else:
+                    merged.append([kind, content, prompt])
+            last_prompted_i = next(
+                (i for i in range(len(merged) - 1, -1, -1)
+                 if merged[i][0] == 'prompted'),
+                None)
+            result = None
+            for i, (kind, content, prompt) in enumerate(merged):
+                if kind == 'gap':
+                    self.Write(content)
+                elif kind == 'prompted':
+                    if i == last_prompted_i:
+                        result = M2Text(content)
+                    else:
+                        self.send_response(self.iopub_socket, 'display_data', {
+                            'data': {'text/plain': content + '\n\n'},
+                            'metadata': {},
+                            'transient': {}
+                        })
+            return result
 
     def get_completions(self, info):
         return [s for s in completion_symbols if s.startswith(info["obj"])]

--- a/m2_kernel/kernel.py
+++ b/m2_kernel/kernel.py
@@ -104,59 +104,118 @@ class M2Kernel(ProcessMetaKernel):
         re.DOTALL | re.VERBOSE
     )
 
+    def _send_display_data(self, html, text):
+        self.send_response(self.iopub_socket, 'display_data', {
+            'data': {'text/html': html, 'text/plain': text},
+            'metadata': {},
+            'transient': {}
+        })
+
+    def _emit_output(self, items):
+        """Pair tagged regions with their text regions; emit gaps as stream,
+        side-effect rich output as display_data, and return the last return-value
+        region as M2Display for execute_result."""
+        regions = []
+        i = 0
+        while i < len(items):
+            kind = items[i][0]
+            if kind == 'gap':
+                regions.append({'kind': 'gap', 'text': items[i][1]})
+                i += 1
+            elif kind in ('prompted', 'unprompted'):
+                content, prompt = items[i][1], items[i][2] if len(items[i]) > 2 else None
+                html = f"<p>{content}</p>\n"
+                text = ''
+                if i + 1 < len(items) and items[i + 1][0] == 'text':
+                    text = items[i + 1][1]
+                    i += 2
+                else:
+                    i += 1
+                # Extract prompt from text when not available from tag (e.g. texmacs).
+                # Use re.MULTILINE because multi-row nets (matrices, types with
+                # superscripts) put the "oN =" or "oN :" on a line that may not
+                # be the first line of the text block.
+                if prompt is None and text:
+                    pm = re.search(r'^(o\d+)\s+[=:]', text, re.MULTILINE)
+                    if pm:
+                        prompt = pm.group(1)
+                regions.append({'kind': kind, 'html': html, 'text': text, 'prompt': prompt})
+            else:  # orphaned text
+                i += 1
+
+        # Merge consecutive prompted regions with the same prompt number so that
+        # Print and AfterPrint for the same value form a single display unit
+        merged = []
+        for r in regions:
+            if (r['kind'] == 'prompted' and merged
+                    and merged[-1]['kind'] == 'prompted'
+                    and r['prompt'] is not None
+                    and merged[-1]['prompt'] == r['prompt']):
+                merged[-1]['html'] += r['html']
+                merged[-1]['text'] += ('\n\n' + r['text'] if merged[-1]['text'] else r['text'])
+            else:
+                merged.append(r)
+        regions = merged
+
+        last_prompted_i = next(
+            (i for i in range(len(regions) - 1, -1, -1)
+             if regions[i]['kind'] == 'prompted'),
+            None)
+
+        result = None
+        for i, r in enumerate(regions):
+            if r['kind'] == 'gap':
+                self.Write(r['text'])
+            elif r['kind'] == 'unprompted':
+                self._send_display_data(r['html'], r['text'] + "\n\n")
+            elif r['kind'] == 'prompted':
+                if i == last_prompted_i:
+                    result = M2Display(r['html'], r['text'])
+                else:
+                    self._send_display_data(r['html'], r['text'] + "\n\n")
+        return result
+
     def do_execute_direct(self, code, silent=False):
         # run parent do_execute_direct silently so we can modify the output
         output = super().do_execute_direct(code, True)
 
         if self.mode == "webapp":
             output = repr(output)
-            html = []
-            text = []
+            items = []
             pos = 0
-
             for m in self.webapp_regex.finditer(output):
                 gap = output[pos:m.start()].strip()
                 if gap:
-                    html.append(f"<pre>{gap}</pre>\n")
-                    text.append(gap)
-                if m.group(5) is not None:          # native text region
-                    text.append(m.group(5))
-                else:                                # rich HTML region
-                    p = re.sub(r"[\x0e\x11\x12]", "", m.group(0))
-                    html.append(f"<p>{p}</p>\n")
+                    items.append(('gap', gap))
+                if m.group(5) is not None:
+                    items.append(('text', m.group(5)))
+                elif m.group(1) is not None:
+                    items.append(('prompted', re.sub(r"[\x0e\x11\x12]", "", m.group(0)), m.group(1)))
+                else:
+                    items.append(('unprompted', re.sub(r"[\x0e\x11\x12]", "", m.group(0))))
                 pos = m.end()
-
             gap = output[pos:].strip()
             if gap:
-                html.append(f"<pre>{gap}</pre>\n")
-                text.append(gap)
-
-            return M2Display("".join(html), "\n\n".join(text))
+                items.append(('gap', gap))
+            return self._emit_output(items)
 
         elif self.mode == "texmacs":
             output = repr(output)
-            html = []
-            text = []
+            items = []
             pos = 0
-
             for m in self.texmacs_regex.finditer(output):
                 gap = output[pos:m.start()].strip()
                 if gap:
-                    html.append(f"<pre>{gap}</pre>\n")
-                    text.append(gap)
-                if m.group(2) is not None:          # native text region
-                    text.append(m.group(2))
-                else:                                # rich HTML region
-                    p = re.sub(r"\x02html:|\x05", "", m.group(0))
-                    html.append(f"<p>{p}</p>\n")
+                    items.append(('gap', gap))
+                if m.group(2) is not None:
+                    items.append(('text', m.group(2)))
+                else:
+                    items.append(('prompted', re.sub(r"\x02html:|\x05", "", m.group(0))))
                 pos = m.end()
-
             gap = output[pos:].strip()
             if gap:
-                html.append(f"<pre>{gap}</pre>\n")
-                text.append(gap)
-
-            return M2Display("".join(html), "\n\n".join(text))
+                items.append(('gap', gap))
+            return self._emit_output(items)
 
         else:  # standard mode
             output = repr(output).strip()

--- a/m2_kernel/kernel.py
+++ b/m2_kernel/kernel.py
@@ -2,19 +2,22 @@ import os
 import re
 import sys
 import configparser
-import html2text
 import subprocess
 from metakernel.process_metakernel import ProcessMetaKernel
 from metakernel.replwrap import REPLWrapper
-from IPython.display import HTML
 from .symbols import completion_symbols
 from .mode_magic import ModeMagic
 from ._version import __version__
 
-class HTMLWithTextFallback(HTML):
-    "Provide text fallback for html output outside of web browsers."
+class M2Display:
+    "Rich display object carrying independent HTML and native-text representations."
+    def __init__(self, html, text):
+        self._html = html
+        self._text = text
+    def _repr_html_(self):
+        return self._html
     def __repr__(self):
-        return html2text.html2text(self._repr_html_())
+        return self._text
 
 class M2Kernel(ProcessMetaKernel):
     implementation = "macaulay2_jupyter_kernel"
@@ -80,12 +83,19 @@ class M2Kernel(ProcessMetaKernel):
 
     webapp_regex = re.compile(
         r"""
-        \x0e([^\x12]*)\x12([^\x11]*)\x11([^\x12]*)\x12 # with prompt
-        | \x11([^\x12]*)\x12                           # without prompt
+        \x0e([^\x12]*)\x12([^\x11]*)\x11([^\x12]*)\x12 # rich: with prompt
+        | \x11([^\x12]*)\x12                           # rich: without prompt
+        | \x1f(.*?)\x16                                # native text region
         """,
         re.DOTALL | re.VERBOSE
     )
-    texmacs_regex = re.compile(r"\x02html:([^\x05]*)\x05", re.DOTALL)
+    texmacs_regex = re.compile(
+        r"""
+        \x02html:([^\x05]*)\x05   # rich html region
+        | \x1f(.*?)\x16           # native text region
+        """,
+        re.DOTALL | re.VERBOSE
+    )
 
     def do_execute_direct(self, code, silent=False):
         # run parent do_execute_direct silently so we can modify the output
@@ -94,40 +104,52 @@ class M2Kernel(ProcessMetaKernel):
         if self.mode == "webapp":
             output = repr(output)
             html = []
+            text = []
             pos = 0
 
             for m in self.webapp_regex.finditer(output):
-                pre = output[pos:m.start()].strip()
-                if pre:
-                    html.append(f"<pre>{pre}</pre>\n")
-                p = re.sub(r"[\x0e\x11\x12]", "",  m.group(0))
-                html.append(f"<p>{p}</p>\n")
+                gap = output[pos:m.start()].strip()
+                if gap:
+                    html.append(f"<pre>{gap}</pre>\n")
+                    text.append(gap)
+                if m.group(5) is not None:          # native text region
+                    text.append(m.group(5))
+                else:                                # rich HTML region
+                    p = re.sub(r"[\x0e\x11\x12]", "", m.group(0))
+                    html.append(f"<p>{p}</p>\n")
                 pos = m.end()
 
-            pre = output[pos:].strip()
-            if pre:
-                html.append(f"<pre>{pre}</pre>\n")
+            gap = output[pos:].strip()
+            if gap:
+                html.append(f"<pre>{gap}</pre>\n")
+                text.append(gap)
 
-            return HTMLWithTextFallback("".join(html))
+            return M2Display("".join(html), "\n\n".join(text))
 
         elif self.mode == "texmacs":
             output = repr(output)
             html = []
+            text = []
             pos = 0
 
             for m in self.texmacs_regex.finditer(output):
-                pre = output[pos:m.start()].strip()
-                if pre:
-                    html.append(f"<pre>{pre}</pre>\n")
-                p = re.sub(r"\x02html:|\x05", "", m.group(0))
-                html.append(f"<p>{p}</p>\n")
+                gap = output[pos:m.start()].strip()
+                if gap:
+                    html.append(f"<pre>{gap}</pre>\n")
+                    text.append(gap)
+                if m.group(2) is not None:          # native text region
+                    text.append(m.group(2))
+                else:                                # rich HTML region
+                    p = re.sub(r"\x02html:|\x05", "", m.group(0))
+                    html.append(f"<p>{p}</p>\n")
                 pos = m.end()
 
-            pre = output[pos:].strip()
-            if pre:
-                html.append(f"<pre>{pre}</pre>\n")
+            gap = output[pos:].strip()
+            if gap:
+                html.append(f"<pre>{gap}</pre>\n")
+                text.append(gap)
 
-            return HTMLWithTextFallback("".join(html))
+            return M2Display("".join(html), "\n\n".join(text))
 
         else:
             self.Write(repr(output))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "setuptools.build_meta"
 name = "macaulay2-jupyter-kernel"
 version = "0.8.1"
 dependencies = [
-	     "html2text",
 	     "jupyterlab-macaulay2",
 	     "jupyterlab_linewrapcellouput",
 	     "metakernel",

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6,7 +6,7 @@ class M2KernelTests(jkt.KernelTests):
     kernel_name = "m2"
     language_name = "Macaulay2"
     file_extension = ".m2"
-    code_hello_world = "\"hello, world\""
+    code_hello_world = 'print "hello, world"'
 
     def setUp(self):
         self.flush_channels()


### PR DESCRIPTION
Previously, the kernel used `html2text` to convert HTML output into the
`text/plain` MIME type shown in terminal frontends (jupyter console,
plain-text clients). Since M2's HTML output renders mathematics using
MathJax with `$...$`-delimited TeX, `html2text` would pass those TeX
expressions through literally, producing unreadable output like
`$R^{2}\,\longleftarrow \,R^{2}$` instead of `R  <-- R`.

This PR replaces that approach with native M2 text output. Each result is
now emitted twice in a single evaluation: once as rich HTML/MathJax (as
before), and once as the native `net`-formatted text that M2 produces in a
regular terminal session. The Python kernel routes each into the correct
MIME type bucket, so notebook frontends continue to render HTML while
terminal frontends see properly aligned native M2 output.

Output routing is now consistent with IPython conventions: the final return
value of a cell is sent as `execute_result` (gets the `Out[N]` label and is
stored in `Out`), while earlier intermediate values and side-effect outputs
are sent as `display_data` and `stream` respectively.

## Changes

- `JupyterKernel.m2`: `Print`, `AfterPrint`, and `AfterNoPrint` now emit a
  native text region (delimited by new control characters `\x1f`/`\x16`)
  alongside the existing rich HTML region. The `print` function (lowercase)
  uses the mode's own print method when available, falling back to a plain
  stdout write otherwise.

- `kernel.py`: Replaces `HTMLWithTextFallback`/`html2text` with `M2Display`
  (carrying independent `text/html` and `text/plain` representations) and
  `M2Text` (plain text for standard mode). A new `_emit_output` helper
  routes tagged regions by type: the last prompted output (Print + AfterPrint
  for the same output number, merged into one unit) becomes `execute_result`;
  earlier intermediate values become `display_data`; unprompted rich output
  (e.g. `show`, `IMG`) becomes `display_data`; and side-effect text between
  tagged regions goes to `stream`. For texmacs mode, the output number is
  extracted from the paired native-text region (the HTML tag carries no
  prompt marker), using `re.MULTILINE` to handle multi-row nets where the
  prompt line is not the first line (e.g. matrix type lines with dimension
  superscripts). Standard mode parses the plain-text output on `oN =` / `oN
  :` boundaries to apply the same routing without control-character tags.

- `pyproject.toml`: Removes the `html2text` dependency.
