### PR TITLE
Enable four previously-skipped jupyter_kernel_test tests

### DIFF
--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -8,6 +8,16 @@ class M2KernelTests(jkt.KernelTests):
     file_extension = ".m2"
     code_hello_world = 'print "hello, world"'
 
+    # Two statements in one cell: first result → display_data, second → execute_result
+    code_display_data = [{"code": "1\n2", "mime": "text/plain"}]
+
+    code_execute_result = [{"code": "1 + 1"}]
+
+    completion_samples = [{"text": "ring"}]
+
+    complete_code_samples = ["1 + 1\n"]
+    incomplete_code_samples = ["1 + 1"]
+
     def setUp(self):
         self.flush_channels()
         self.execute_helper(code="%mode standard")


### PR DESCRIPTION
Add test fixtures for execute_result, completion, is_complete, and display_data, bringing passing tests from 2/12 to 6/12.